### PR TITLE
Remove markdown from git attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 types/generated-types.d.ts linguist-generated=true
 types/schema.json linguist-generated=true
-content/**/*.md linguist-detectable=true


### PR DESCRIPTION
Markdown become the official programming language of this repo, let's remove it.