### PR TITLE
Add gatsby-ssr.ts to remove inline CSS on every page

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,8 +1,10 @@
 // Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
 // Read the LICENSE file in the repository root for full license text.
 
-import "./src/styles/index.scss";
+import "@fontsource/rubik/500.css";
+import "@fontsource/rubik/800.css";
+import "@fontsource/lato/400.css";
+import "@fontsource/lato/700.css";
 import "@fortawesome/fontawesome-svg-core/styles.css";
-
-// Code blocks highlight
-import "prismjs/themes/prism.css";
+import "prismjs/themes/prism-tomorrow.css";
+import "./src/styles/index.scss";

--- a/gatsby-ssr.ts
+++ b/gatsby-ssr.ts
@@ -1,0 +1,33 @@
+// Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ReactElement } from "react";
+import { GatsbySSR, PreRenderHTMLArgs } from "gatsby";
+
+// This is workaround for
+// https://github.com/gagahpangeran/blog.gagahpangeran.com/issues/83
+// Code is copied and adapted to typescript from
+// https://github.com/gatsbyjs/gatsby/issues/1526#issuecomment-639993049
+export const onPreRenderHTML: GatsbySSR["onPreRenderHTML"] = ({
+  getHeadComponents
+}: PreRenderHTMLArgs): any => {
+  if (process.env.NODE_ENV !== "production") {
+    return;
+  }
+
+  getHeadComponents().forEach(elem => {
+    const el = elem as ReactElement;
+
+    if (el.type === "style" && el.props["data-href"]) {
+      el.type = "link";
+
+      el.props["href"] = el.props["data-href"];
+      el.props["rel"] = "stylesheet";
+      el.props["type"] = "text/css";
+
+      delete el.props["data-href"];
+      delete el.props["dangerouslySetInnerHTML"];
+    }
+  });
+};

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,11 +1,6 @@
 // Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
 // Read the LICENSE file in the repository root for full license text.
 
-@import "~@fontsource/rubik/500.css";
-@import "~@fontsource/rubik/800.css";
-@import "~@fontsource/lato/400.css";
-@import "~@fontsource/lato/700.css";
-
 :root {
   --bg-dark: #16161a;
   --bg-light: #242629;


### PR DESCRIPTION
A little benchmark between this PR and current master https://github.com/gagahpangeran/blog.gagahpangeran.com/commit/41a0edd6e37b3f3c142dc8487268994d3f02608e

Benchmarking file size of html file for production in `public` directory after running script `rm -rf public/ && yarn build` on root directory of this repo.

**Before (current master)**

```bash
$ find public/ -name "*.html" -type f -exec du -sh {} \;
68K	public/blog-revamp/index.html
80K	public/torrent-to-google-drive-using-google-colab/index.html
136K	public/klik-klik-berhadiah-di-secure-code-warrior/index.html
92K	public/recap-2018/index.html
76K	public/index.html
60K	public/404/index.html
60K	public/404.html
64K	public/category/competition/index.html
72K	public/category/story/index.html
68K	public/category/tech/index.html
64K	public/tag/blog-revamp/index.html
64K	public/tag/college/index.html
64K	public/tag/dev-ops-day-jakarta/index.html
64K	public/tag/fasilkom/index.html
64K	public/tag/gatsby/index.html
64K	public/tag/google-colab/index.html
64K	public/tag/google-drive/index.html
64K	public/tag/markdown/index.html
64K	public/tag/secure-code-warrior/index.html
64K	public/tag/torrent/index.html
68K	public/lang/en/index.html
68K	public/lang/id/index.html

$ find public/ -name "*.css" -type f -exec du -sh {} \;
56K	public/styles.2fc7689211c5cc985154.css
```

**After (this PR)**

```bash
$ find public/ -name "*.html" -type f -exec du -sh {} \;
16K	public/blog-revamp/index.html
28K	public/torrent-to-google-drive-using-google-colab/index.html
80K	public/klik-klik-berhadiah-di-secure-code-warrior/index.html
40K	public/recap-2018/index.html
24K	public/index.html
8.0K	public/404/index.html
8.0K	public/404.html
12K	public/category/competition/index.html
20K	public/category/story/index.html
16K	public/category/tech/index.html
12K	public/tag/blog-revamp/index.html
12K	public/tag/college/index.html
12K	public/tag/dev-ops-day-jakarta/index.html
12K	public/tag/fasilkom/index.html
12K	public/tag/gatsby/index.html
12K	public/tag/google-colab/index.html
12K	public/tag/google-drive/index.html
12K	public/tag/markdown/index.html
12K	public/tag/secure-code-warrior/index.html
12K	public/tag/torrent/index.html
16K	public/lang/en/index.html
16K	public/lang/id/index.html

$ find public/ -name "*.css" -type f -exec du -sh {} \;
56K	public/styles.57d9ddf26aa93c56cdfe.css
```

Obviously this benchmark probably not represent load time in production. But hopefully reduce it by only fetch CSS file once and let the browser cache it instead of using inline CSS on every page.