### PR TITLE
Add initial prismjs custom styling for code block

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,8 +1,10 @@
 // Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
 // Read the LICENSE file in the repository root for full license text.
 
-import "./src/styles/index.scss";
+import "@fontsource/rubik/500.css";
+import "@fontsource/rubik/800.css";
+import "@fontsource/lato/400.css";
+import "@fontsource/lato/700.css";
 import "@fortawesome/fontawesome-svg-core/styles.css";
-
-// Code blocks highlight
-import "prismjs/themes/prism.css";
+import "prismjs/themes/prism-tomorrow.css";
+import "./src/styles/index.scss";

--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -5,6 +5,7 @@ import "@fontsource/rubik/500.css";
 import "@fontsource/rubik/800.css";
 import "@fontsource/lato/400.css";
 import "@fontsource/lato/700.css";
+import "@fontsource/fira-code";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "prismjs/themes/prism-tomorrow.css";
 import "./src/styles/index.scss";

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "GPR <gpr@gagahpangeran.com>",
   "dependencies": {
+    "@fontsource/fira-code": "^4.2.1",
     "@fontsource/lato": "^4.2.1",
     "@fontsource/rubik": "^4.2.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.34",

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,11 +1,6 @@
 // Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
 // Read the LICENSE file in the repository root for full license text.
 
-@import "~@fontsource/rubik/500.css";
-@import "~@fontsource/rubik/800.css";
-@import "~@fontsource/lato/400.css";
-@import "~@fontsource/lato/700.css";
-
 :root {
   --bg-dark: #16161a;
   --bg-light: #242629;

--- a/src/styles/code-block.scss
+++ b/src/styles/code-block.scss
@@ -1,0 +1,46 @@
+// Copyright (c) GPR <gpr@gagahpangeran.com>. Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text.
+
+// Selector for inline code
+$inline: 'code[class*="language-"]';
+
+// Selector for code block
+$block: 'pre[class*="language-"]';
+
+#{$inline},
+#{$block} {
+  font-size: 1.125rem;
+}
+
+#{$block} {
+  padding: 8px 16px;
+}
+
+:not(pre) > #{$inline},
+#{$block} {
+  background: var(--bg-dark);
+}
+
+.token {
+  &.string,
+  &.char,
+  &.attr-value,
+  &.regex,
+  &.variable {
+    color: var(--green);
+  }
+
+  &.boolean,
+  &.number,
+  &.function {
+    color: var(--orange);
+  }
+
+  &.selector,
+  &.important,
+  &.atrule,
+  &.keyword,
+  &.builtin {
+    color: var(--purple);
+  }
+}

--- a/src/styles/code-block.scss
+++ b/src/styles/code-block.scss
@@ -20,6 +20,21 @@ $block: 'pre[class*="language-"]';
 
 #{$block} {
   padding: 8px 16px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray) var(--white);
+
+  &::-webkit-scrollbar {
+    width: 10px;
+    background-color: var(--white);
+
+    &:horizontal {
+      height: 6px;
+    }
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--gray);
+  }
 }
 
 :not(pre) > #{$inline},

--- a/src/styles/code-block.scss
+++ b/src/styles/code-block.scss
@@ -10,6 +10,12 @@ $block: 'pre[class*="language-"]';
 #{$inline},
 #{$block} {
   font-size: 1.125rem;
+  font-family: "Fira Code", Consolas, Monaco, "Andale Mono", "Ubuntu Mono",
+    monospace;
+
+  @media screen and (max-width: 480px) {
+    font-size: 1rem;
+  }
 }
 
 #{$block} {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,6 +2,7 @@
 // Read the LICENSE file in the repository root for full license text.
 
 @import "base.scss";
+@import "code-block.scss";
 @import "not-found.scss";
 @import "navbar.scss";
 @import "header.scss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@fontsource/fira-code@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@fontsource/fira-code/-/fira-code-4.2.1.tgz#02cb6d98d38bde1201a968dbf10f269b227bbbfc"
+  integrity sha512-cbhLAAuIg0lqZ+KH8e0PNc354lXMCOE58QfT9Xh6zIrtCaGtEaLeQndqbMWPpxI5cC4uRa3V4aq/xBtHBdgxSw==
+
 "@fontsource/lato@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@fontsource/lato/-/lato-4.2.1.tgz#6bc81159b0d762bf72dc750afac228f3529e8a5b"


### PR DESCRIPTION
closed #22 

- Override some spacing.
- Override font size.
- Override coloring by using existed color variable.
- Use Fira Code font as default font.
- Customize scrollbar size and color.

Will look in the future :
- Basically every customization from https://www.gatsbyjs.com/plugins/gatsby-remark-prismjs/
- Add copy button (this will be a little complicated). Reference https://prismjs.com/plugins/copy-to-clipboard/