### PR TITLE
Simplify `createPaginatedPageData` function

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -3,6 +3,7 @@
 // Read the LICENSE file in the repository root for full license text
 
 import path from "path";
+import kebabCase from "lodash.kebabcase";
 import { createFilePath } from "gatsby-source-filesystem";
 import { CreateSchemaCustomizationArgs, GatsbyNode } from "gatsby";
 import { createPaginatedPageData } from "./src/utils/gatsby";
@@ -124,14 +125,16 @@ export const createPages: GatsbyNode["createPages"] = async ({
 
   const indexPageData = createPaginatedPageData({
     postCount: posts.length,
-    type: "Blog"
+    type: "Blog",
+    basePath: "/blog/"
   });
 
   const categoriesPageData = categories.flatMap(category =>
     createPaginatedPageData({
       postCount: category.totalCount,
       filterValue: category.fieldValue,
-      type: "Category"
+      type: "Category",
+      basePath: `/blog/category/${kebabCase(category.fieldValue)}/`
     })
   );
 
@@ -139,7 +142,8 @@ export const createPages: GatsbyNode["createPages"] = async ({
     createPaginatedPageData({
       postCount: tag.totalCount,
       filterValue: tag.fieldValue,
-      type: "Tag"
+      type: "Tag",
+      basePath: `/blog/tag/${kebabCase(tag.fieldValue)}/`
     })
   );
 
@@ -147,8 +151,8 @@ export const createPages: GatsbyNode["createPages"] = async ({
     createPaginatedPageData({
       postCount: lang.totalCount,
       filterValue: lang.fieldValue,
-      slug: "lang",
-      type: "Language"
+      type: "Language",
+      basePath: `/blog/lang/${kebabCase(lang.fieldValue)}/`
     })
   );
 

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -5,7 +5,7 @@
 import path from "path";
 import { createFilePath } from "gatsby-source-filesystem";
 import { CreateSchemaCustomizationArgs, GatsbyNode } from "gatsby";
-import { createBlogPageData } from "./src/utils/gatsby";
+import { createPaginatedPageData } from "./src/utils/gatsby";
 
 // Current plugin `gatsby-plugin-typegen` can't generate types from graphql
 // query inside `gatsby-node.ts` yet. There's plan in the future to support it.
@@ -122,13 +122,13 @@ export const createPages: GatsbyNode["createPages"] = async ({
     });
   });
 
-  const indexPageData = createBlogPageData({
+  const indexPageData = createPaginatedPageData({
     postCount: posts.length,
     type: "Blog"
   });
 
   const categoriesPageData = categories.flatMap(category =>
-    createBlogPageData({
+    createPaginatedPageData({
       postCount: category.totalCount,
       filterValue: category.fieldValue,
       type: "Category"
@@ -136,7 +136,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
   );
 
   const tagsPageData = tags.flatMap(tag =>
-    createBlogPageData({
+    createPaginatedPageData({
       postCount: tag.totalCount,
       filterValue: tag.fieldValue,
       type: "Tag"
@@ -144,7 +144,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
   );
 
   const langsPageData = langs.flatMap(lang =>
-    createBlogPageData({
+    createPaginatedPageData({
       postCount: lang.totalCount,
       filterValue: lang.fieldValue,
       slug: "lang",

--- a/src/utils/gatsby.ts
+++ b/src/utils/gatsby.ts
@@ -5,29 +5,29 @@
 import kebabCase from "lodash.kebabcase";
 import { BlogPageContext, BlogPageContextType } from "./data";
 
-export interface CreatePageDataArgs {
+export interface PaginatedPageDataArgs {
   postCount: number;
   type: BlogPageContextType;
   slug?: string;
   filterValue?: string;
 }
 
-export interface CreateBlogPageContext extends BlogPageContext {
+export interface PaginatedBlogPageContext extends BlogPageContext {
   limit: number;
   skip: number;
 }
 
-export interface CreatePageDataType {
+export interface PaginatedPageDataType {
   path: string;
-  context: CreateBlogPageContext;
+  context: PaginatedBlogPageContext;
 }
 
-export function createBlogPageData({
+export function createPaginatedPageData({
   slug,
   postCount,
   filterValue = "",
   type
-}: CreatePageDataArgs): CreatePageDataType[] {
+}: PaginatedPageDataArgs): PaginatedPageDataType[] {
   const postPerPage = 5;
   const numPages = Math.ceil(postCount / postPerPage);
 

--- a/src/utils/gatsby.ts
+++ b/src/utils/gatsby.ts
@@ -2,13 +2,12 @@
 // Licensed under The MIT License.
 // Read the LICENSE file in the repository root for full license text
 
-import kebabCase from "lodash.kebabcase";
 import { BlogPageContext, BlogPageContextType } from "./data";
 
 export interface PaginatedPageDataArgs {
   postCount: number;
   type: BlogPageContextType;
-  slug?: string;
+  basePath: string;
   filterValue?: string;
 }
 
@@ -23,29 +22,13 @@ export interface PaginatedPageDataType {
 }
 
 export function createPaginatedPageData({
-  slug,
+  basePath,
   postCount,
   filterValue = "",
   type
 }: PaginatedPageDataArgs): PaginatedPageDataType[] {
   const postPerPage = 5;
   const numPages = Math.ceil(postCount / postPerPage);
-
-  let basePath = "/blog/";
-
-  if (type !== "Blog") {
-    if (slug === undefined) {
-      basePath += `${type.toLowerCase()}/`;
-    } else {
-      basePath += `${slug}/`;
-    }
-
-    if (filterValue.length > 0) {
-      basePath += `${kebabCase(filterValue)}/`;
-    } else {
-      throw new Error(`filterValue can not be empty if type is not "Blog"`);
-    }
-  }
 
   return Array.from({ length: numPages }).map((_, index) => ({
     path: `${basePath}${index > 0 ? `${index + 1}/` : ""}`,

--- a/test/utils/gatsby.test.ts
+++ b/test/utils/gatsby.test.ts
@@ -3,14 +3,14 @@
 // Read the LICENSE file in the repository root for full license text.
 
 import {
-  CreatePageDataArgs,
-  CreatePageDataType,
-  CreateBlogPageContext,
-  createBlogPageData
+  PaginatedPageDataArgs,
+  PaginatedPageDataType,
+  PaginatedBlogPageContext,
+  createPaginatedPageData
 } from "../../src/utils/gatsby";
 
 const baseContext: Omit<
-  CreateBlogPageContext,
+  PaginatedBlogPageContext,
   "basePath" | "filterValue" | "type"
 > = {
   limit: 5,
@@ -19,39 +19,39 @@ const baseContext: Omit<
   numPages: 1
 };
 
-const baseArgs: CreatePageDataArgs = {
+const baseArgs: PaginatedPageDataArgs = {
   postCount: 1,
   type: "Language",
   slug: "lang",
   filterValue: "en"
 };
 
-const context: CreateBlogPageContext = {
+const context: PaginatedBlogPageContext = {
   ...baseContext,
   basePath: "/blog/lang/en/",
   filterValue: "en",
   type: "Language"
 };
 
-const expectedResult: CreatePageDataType = {
+const expectedResult: PaginatedPageDataType = {
   path: context.basePath,
   context
 };
 
-describe("Test createPageData function", () => {
+describe("Test createPaginatedPageData function", () => {
   test("All arguments filled", () => {
-    const result = createBlogPageData(baseArgs);
+    const result = createPaginatedPageData(baseArgs);
 
     expect(result).toMatchObject([expectedResult]);
   });
 
   test("slug argument empty or undefined", () => {
-    const result = createBlogPageData({
+    const result = createPaginatedPageData({
       ...baseArgs,
       slug: undefined
     });
 
-    const slugExpectedResult: CreatePageDataType = {
+    const slugExpectedResult: PaginatedPageDataType = {
       path: "/blog/language/en/",
       context: {
         ...expectedResult.context,
@@ -63,30 +63,34 @@ describe("Test createPageData function", () => {
   });
 
   test("filterValue (and slug) argument(s) empty or undefined", () => {
-    let filterValueArgs: CreatePageDataArgs = {
+    let filterValueArgs: PaginatedPageDataArgs = {
       ...baseArgs,
       filterValue: undefined
     };
 
     const errorMessage = `filterValue can not be empty if type is not "Blog"`;
 
-    expect(() => createBlogPageData(filterValueArgs)).toThrow(errorMessage);
+    expect(() => createPaginatedPageData(filterValueArgs)).toThrow(
+      errorMessage
+    );
 
     filterValueArgs = {
       ...filterValueArgs,
       slug: undefined
     };
 
-    expect(() => createBlogPageData(filterValueArgs)).toThrow(errorMessage);
+    expect(() => createPaginatedPageData(filterValueArgs)).toThrow(
+      errorMessage
+    );
   });
 
   test("Index type argument", () => {
-    const result = createBlogPageData({
+    const result = createPaginatedPageData({
       postCount: 1,
       type: "Blog"
     });
 
-    const indexTypeExpectedResult: CreatePageDataType = {
+    const indexTypeExpectedResult: PaginatedPageDataType = {
       path: "/blog/",
       context: {
         ...baseContext,
@@ -100,12 +104,12 @@ describe("Test createPageData function", () => {
   });
 
   test("Multiple pages", () => {
-    const result = createBlogPageData({
+    const result = createPaginatedPageData({
       ...baseArgs,
       postCount: 7
     });
 
-    const multiPageExpectedResult: CreatePageDataType[] = [
+    const multiPageExpectedResult: PaginatedPageDataType[] = [
       {
         path: expectedResult.path,
         context: {

--- a/test/utils/gatsby.test.ts
+++ b/test/utils/gatsby.test.ts
@@ -22,13 +22,13 @@ const baseContext: Omit<
 const baseArgs: PaginatedPageDataArgs = {
   postCount: 1,
   type: "Language",
-  slug: "lang",
-  filterValue: "en"
+  filterValue: "en",
+  basePath: "/blog/lang/en"
 };
 
 const context: PaginatedBlogPageContext = {
   ...baseContext,
-  basePath: "/blog/lang/en/",
+  basePath: "/blog/lang/en",
   filterValue: "en",
   type: "Language"
 };
@@ -45,62 +45,16 @@ describe("Test createPaginatedPageData function", () => {
     expect(result).toMatchObject([expectedResult]);
   });
 
-  test("slug argument empty or undefined", () => {
-    const result = createPaginatedPageData({
-      ...baseArgs,
-      slug: undefined
-    });
+  test("Filter value argument is undefined", () => {
+    const args = { ...baseArgs, filterValue: undefined };
+    const result = createPaginatedPageData(args);
 
-    const slugExpectedResult: PaginatedPageDataType = {
-      path: "/blog/language/en/",
-      context: {
-        ...expectedResult.context,
-        basePath: "/blog/language/en/"
-      }
+    const expResult = {
+      ...expectedResult,
+      context: { ...expectedResult.context, filterValue: "" }
     };
 
-    expect(result).toMatchObject([slugExpectedResult]);
-  });
-
-  test("filterValue (and slug) argument(s) empty or undefined", () => {
-    let filterValueArgs: PaginatedPageDataArgs = {
-      ...baseArgs,
-      filterValue: undefined
-    };
-
-    const errorMessage = `filterValue can not be empty if type is not "Blog"`;
-
-    expect(() => createPaginatedPageData(filterValueArgs)).toThrow(
-      errorMessage
-    );
-
-    filterValueArgs = {
-      ...filterValueArgs,
-      slug: undefined
-    };
-
-    expect(() => createPaginatedPageData(filterValueArgs)).toThrow(
-      errorMessage
-    );
-  });
-
-  test("Index type argument", () => {
-    const result = createPaginatedPageData({
-      postCount: 1,
-      type: "Blog"
-    });
-
-    const indexTypeExpectedResult: PaginatedPageDataType = {
-      path: "/blog/",
-      context: {
-        ...baseContext,
-        basePath: "/blog/",
-        filterValue: "",
-        type: "Blog"
-      }
-    };
-
-    expect(result).toMatchObject([indexTypeExpectedResult]);
+    expect(result).toMatchObject([expResult]);
   });
 
   test("Multiple pages", () => {


### PR DESCRIPTION
- Rename `createBlogPageData` to `createPaginatedPageData`.
- Simplify its logic by using `basePath` argument.