### PR TITLE
Add changelog workflow to add new changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,35 @@
+name: Changelog
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  changelog:
+    if: github.event.pull_request.merged == true
+    name: Update changelog in wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup git
+        run: |
+          git config --global user.name "Github Actions"
+          git config --global user.email "actions@users.noreply.github.com"
+
+      - name: Update submodule
+        run: git submodule update --remote
+
+      - name: Add new changelog
+        run: |
+          git -C content/changelog checkout master
+          echo "- [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" >> changelog/Next.md
+
+      - name: Commit and push changelog
+        run: |
+          git -C content/changelog add .
+          git -C content/changelog commit -m "Add new changelog #${{ github.event.pull_request.number }}"
+          git -C content/changelog push origin master


### PR DESCRIPTION
Basically how this works is everytime PR is merged, it updates the `Next.md` file in wiki with new changelog.

Just read the code, it should very clear with a bunch of git command.