### PR TITLE
Add workflow when create PR changing `content` directory

### DIFF
--- a/.github/workflows/content-pr.yml
+++ b/.github/workflows/content-pr.yml
@@ -1,0 +1,40 @@
+name: Content PR
+on:
+  pull_request:
+    paths: ["content/**"]
+    types: [opened]
+
+jobs:
+  add-label:
+    if: "!contains(github.event.pull_request.labels.*.name, 'type:content')"
+    name: Check content label
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['type:content']
+            })
+
+  label-reminder:
+    if: "!contains(github.event.pull_request.labels.*.name, 'update-content')"
+    name: Remind update content label
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This PR is updating `content` directory. Please add label `update-content` if you want auto-deploy it after this PR is merged to master.'
+            })


### PR DESCRIPTION
This workflow has 2 jobs:
- If there's not `type:content` label, it will automatically be added
- If there's not `update-content` label, it will reminds about it in the comment

Complement for #129 