### PR TITLE
Change double quote to single quote in changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Add new changelog
         run: |
           git -C content/changelog checkout master
-          echo "- [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})" >> content/changelog/Next.md
+          echo '- [${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})' >> content/changelog/Next.md
 
       - name: Commit and push changelog
         run: |


### PR DESCRIPTION
This is to prevent PR's title with backtick being execute in bash and also fix the missing word inside backtick.