### PR TITLE
Filter out changelog next in changelog page

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -83,7 +83,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
         filter: {
           fields: {
             type: { eq: "changelog" }
-            slug: { ne: "/changelog/Home/" }
+            slug: { nin: ["/changelog/Home/", "/changelog/Next/"] }
           }
         }
         sort: { fields: fields___slug, order: DESC }

--- a/src/pages/changelog.tsx
+++ b/src/pages/changelog.tsx
@@ -37,7 +37,10 @@ export const pageQuery = graphql`
   query Changelog {
     allChangelog: allMarkdownRemark(
       filter: {
-        fields: { type: { eq: "changelog" }, slug: { ne: "/changelog/Home/" } }
+        fields: {
+          type: { eq: "changelog" }
+          slug: { nin: ["/changelog/Home/", "/changelog/Next/"] }
+        }
       }
       sort: { fields: fields___slug, order: DESC }
     ) {


### PR DESCRIPTION
`Next` file inside changelog is almost impossible because we only update changelog submodule in `master` when there's new release, and the file `Next` is already rename to release tag version.

This is just for sanity check and filter.