### PR TITLE
Fix incorrect path in post language label

### DIFF
--- a/src/components/PostLabel.tsx
+++ b/src/components/PostLabel.tsx
@@ -39,7 +39,7 @@ const PostLabel = ({ categories, tags, lang }: Props) => {
         </Link>
       ))}
       <Link
-        to={`/lang/${lang}/`}
+        to={`/blog/lang/${lang}/`}
         className="post-label__link post-label__link--lang"
       >
         {langMap.get(lang) ?? "English"}


### PR DESCRIPTION
I surprise that I didn't notice this bug for such long time.