### PR TITLE
Use first paragraph as post description

### DIFF
--- a/content/blog/blog-revamp/index.md
+++ b/content/blog/blog-revamp/index.md
@@ -5,9 +5,6 @@
 
 title: "Blog Revamp"
 date: "2021-02-17T15:16:00+07:00"
-description:
-  "Currently I'm still revamping and fixing this blog after my VPS died and also
-  causing this blog's backend, that using wordpress, died."
 featuredImage: "./img/wp-md.png"
 tags: ["Story", "Tech", "Blog Revamp", "Markdown", "Gatsby"]
 lang: "en"

--- a/content/blog/blog-revamp/index.md
+++ b/content/blog/blog-revamp/index.md
@@ -16,6 +16,8 @@ lang: "en"
 Currently I'm still revamping and fixing this blog after my VPS died and also
 causing this blog's backend, that using wordpress, died.
 
+<!-- excerpt -->
+
 The effect is many of the images did not load because it is hosted in wordpress.
 Fortunately, because Gatsby pull out all data from wordpress when built, the
 post is saved and I still have the images of all post in my hard drive.

--- a/content/blog/klik-klik-berhadiah-di-secure-code-warrior/index.md
+++ b/content/blog/klik-klik-berhadiah-di-secure-code-warrior/index.md
@@ -20,6 +20,8 @@ dapat juara 3 di lomba Secure Code Warrior atau disingkat SCW. Jadi apa sih itu
 SCW? Apakah ada hubungannya dengan SJW? Gimana caranya gue bisa menang padahal
 dikejar-kejar deadline PPL? Nah gini ceritanya.
 
+<!-- excerpt -->
+
 ## Pendaftaran
 
 Jadi gue baru tahu lomba SCW dari grup Lomba Hunter Fasilkom, di hari minggu 2

--- a/content/blog/klik-klik-berhadiah-di-secure-code-warrior/index.md
+++ b/content/blog/klik-klik-berhadiah-di-secure-code-warrior/index.md
@@ -5,11 +5,6 @@
 
 title: "Klik-klik Berhadiah di Secure Code Warrior"
 date: "2020-03-20T18:35:00+07:00"
-description:
-  "Jadi ceritanya minggu lalu gue dan Distra dapat juara 3 di lomba Secure Code
-  Warrior atau disingkat SCW. Jadi apa sih itu SCW? Apakah ada hubungannya
-  dengan SJW? Gimana caranya gue bisa menang padahal dikejar-kejar deadline PPL?
-  Nah gini ceritanya."
 featuredImage: "./img/scw.png"
 tags: ["Story", "Competition", "DevOpsDay Jakarta", "Secure Code Warrior"]
 lang: "id"

--- a/content/blog/recap-2018/index.md
+++ b/content/blog/recap-2018/index.md
@@ -5,9 +5,6 @@
 
 title: "Recap 2018"
 date: "2019-01-01T20:21:00+07:00"
-description:
-  "Recap kehidupan gue selama 2018 kemarin akhirnya ditulis juga. Jadi kali ini
-  gue akan menulis tentang apa saja yang gue lakukan di 2018 kemarin."
 featuredImage: "./img/misan-evergarden.jpg"
 tags: ["Story", "Fasilkom", "College"]
 lang: "id"

--- a/content/blog/recap-2018/index.md
+++ b/content/blog/recap-2018/index.md
@@ -16,6 +16,8 @@ lang: "id"
 Recap kehidupan gue selama 2018 kemarin akhirnya ditulis juga. Jadi kali ini gue
 akan menulis tentang apa saja yang gue lakukan di 2018 kemarin.
 
+<!-- excerpt -->
+
 ## Ikutan 30 Hari bercerita
 
 Jadi di Instagram ada event yang namanya 30 hari bercerita. Untuk mengembalikan

--- a/content/blog/torrent-to-google-drive-using-google-colab/index.md
+++ b/content/blog/torrent-to-google-drive-using-google-colab/index.md
@@ -5,9 +5,6 @@
 
 title: "Torrent to Google Drive Using Google Colab"
 date: "2019-07-29T20:59:00+07:00"
-description:
-  "Have you ever thought of downloading a Torrent and saving it directly to
-  Google Drive? I found one of the tricks, using Google Colab."
 featuredImage: "./img/torrent-to-gdrive.png"
 tags: ["Tech", "Google Colab", "Google Drive", "Torrent"]
 lang: "en"

--- a/content/blog/torrent-to-google-drive-using-google-colab/index.md
+++ b/content/blog/torrent-to-google-drive-using-google-colab/index.md
@@ -16,6 +16,8 @@ lang: "en"
 Have you ever thought of downloading a Torrent and saving it directly to Google
 Drive? I found one of the tricks, using Google Colab.
 
+<!-- excerpt -->
+
 First, this is my new blog and all my old posts have been archived. Now I use
 Gatsby js + WordPress to build this blog. You can find many tutorials on the
 internet. This blog is still in developing and there are still many features

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -23,6 +23,7 @@ export const plugins: GatsbyConfig["plugins"] = [
   {
     resolve: `gatsby-transformer-remark`,
     options: {
+      excerpt_separator: "<!-- excerpt -->",
       plugins: [
         {
           resolve: `gatsby-remark-images`,

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -237,7 +237,6 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
 
     type Frontmatter {
       date: Date! @dateformat
-      description: String!
       lang: String!
       tags: [String!]!
       title: String!

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -232,6 +232,7 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
       frontmatter: Frontmatter!
       fields: Fields!
       html: String!
+      excerpt: String!
     }
 
     type Frontmatter {

--- a/src/templates/Post.tsx
+++ b/src/templates/Post.tsx
@@ -69,6 +69,7 @@ export const pageQuery = graphql`
     fields {
       slug
     }
+    excerpt
     frontmatter {
       title
       description

--- a/src/templates/Post.tsx
+++ b/src/templates/Post.tsx
@@ -72,7 +72,6 @@ export const pageQuery = graphql`
     excerpt
     frontmatter {
       title
-      description
       date(formatString: "MMMM DD, YYYY")
       tags
       lang

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -28,11 +28,16 @@ export const postKeyMap: {
 };
 
 export function getPostData(data: GatsbyTypes.PostDetailFragment) {
-  const { id, html, fields, frontmatter } = data;
+  const { id, html, excerpt, fields, frontmatter } = data;
+
+  if (excerpt == null) {
+    throw new Error("Post does not have any excerpt");
+  }
 
   return {
     id,
     ...frontmatter,
+    description: excerpt,
     slug: fields.slug,
     html: html ?? "",
     image: frontmatter?.featuredImage?.childImageSharp

--- a/types/generated-types.d.ts
+++ b/types/generated-types.d.ts
@@ -3963,13 +3963,13 @@ type ImageSharpSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
-type SiteMetaDataQueryVariables = Exact<{ [key: string]: never; }>;
+type ChangelogQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type SiteMetaDataQuery = { readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'image'> }> };
+type ChangelogQuery = { readonly allChangelog: { readonly nodes: ReadonlyArray<{ readonly fields: Pick<Fields, 'slug'> }> } };
 
 type PostDetailFragment = (
-  Pick<MarkdownRemark, 'id' | 'html'>
+  Pick<MarkdownRemark, 'id' | 'html' | 'excerpt'>
   & { readonly fields: Pick<Fields, 'slug'>, readonly frontmatter: (
     Pick<Frontmatter, 'title' | 'description' | 'date' | 'tags' | 'lang'>
     & { readonly featuredImage: Maybe<(
@@ -4000,6 +4000,11 @@ type ChangelogTemplateQuery = { readonly changelog: Maybe<(
     & { readonly fields: Pick<Fields, 'slug'> }
   )>, readonly newerChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }>, readonly olderChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }> };
 
+type SiteMetaDataQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type SiteMetaDataQuery = { readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'image'> }> };
+
 type PostTemplateQueryVariables = Exact<{
   id: Scalars['String'];
   newerId: Maybe<Scalars['String']>;
@@ -4008,11 +4013,6 @@ type PostTemplateQueryVariables = Exact<{
 
 
 type PostTemplateQuery = { readonly post: Maybe<PostDetailFragment>, readonly newerPost: Maybe<PostDetailFragment>, readonly olderPost: Maybe<PostDetailFragment>, readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'siteUrl'> }> };
-
-type ChangelogQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type ChangelogQuery = { readonly allChangelog: { readonly nodes: ReadonlyArray<{ readonly fields: Pick<Fields, 'slug'> }> } };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 

--- a/types/generated-types.d.ts
+++ b/types/generated-types.d.ts
@@ -350,6 +350,7 @@ type SitePluginPluginOptions = {
   readonly plugins: Maybe<ReadonlyArray<Maybe<SitePluginPluginOptionsPlugins>>>;
   readonly path: Maybe<Scalars['String']>;
   readonly name: Maybe<Scalars['String']>;
+  readonly excerpt_separator: Maybe<Scalars['String']>;
   readonly maxWidth: Maybe<Scalars['Int']>;
   readonly showCaptions: Maybe<Scalars['Boolean']>;
   readonly backgroundColor: Maybe<Scalars['String']>;
@@ -2587,6 +2588,7 @@ type SitePluginPluginOptionsFilterInput = {
   readonly plugins: Maybe<SitePluginPluginOptionsPluginsFilterListInput>;
   readonly path: Maybe<StringQueryOperatorInput>;
   readonly name: Maybe<StringQueryOperatorInput>;
+  readonly excerpt_separator: Maybe<StringQueryOperatorInput>;
   readonly maxWidth: Maybe<IntQueryOperatorInput>;
   readonly showCaptions: Maybe<BooleanQueryOperatorInput>;
   readonly backgroundColor: Maybe<StringQueryOperatorInput>;
@@ -2865,6 +2867,7 @@ type SitePageFieldsEnum =
   | 'pluginCreator.pluginOptions.plugins.pluginFilepath'
   | 'pluginCreator.pluginOptions.path'
   | 'pluginCreator.pluginOptions.name'
+  | 'pluginCreator.pluginOptions.excerpt_separator'
   | 'pluginCreator.pluginOptions.maxWidth'
   | 'pluginCreator.pluginOptions.showCaptions'
   | 'pluginCreator.pluginOptions.backgroundColor'
@@ -3096,6 +3099,7 @@ type SitePluginFieldsEnum =
   | 'pluginOptions.plugins.pluginFilepath'
   | 'pluginOptions.path'
   | 'pluginOptions.name'
+  | 'pluginOptions.excerpt_separator'
   | 'pluginOptions.maxWidth'
   | 'pluginOptions.showCaptions'
   | 'pluginOptions.backgroundColor'
@@ -3964,11 +3968,6 @@ type SiteMetaDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 type SiteMetaDataQuery = { readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'image'> }> };
 
-type ChangelogQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type ChangelogQuery = { readonly allChangelog: { readonly nodes: ReadonlyArray<{ readonly fields: Pick<Fields, 'slug'> }> } };
-
 type PostDetailFragment = (
   Pick<MarkdownRemark, 'id' | 'html'>
   & { readonly fields: Pick<Fields, 'slug'>, readonly frontmatter: (
@@ -3989,15 +3988,6 @@ type BlogTemplateQueryVariables = Exact<{
 
 type BlogTemplateQuery = { readonly posts: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly tags: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly langs: { readonly nodes: ReadonlyArray<PostDetailFragment> } };
 
-type PostTemplateQueryVariables = Exact<{
-  id: Scalars['String'];
-  newerId: Maybe<Scalars['String']>;
-  olderId: Maybe<Scalars['String']>;
-}>;
-
-
-type PostTemplateQuery = { readonly post: Maybe<PostDetailFragment>, readonly newerPost: Maybe<PostDetailFragment>, readonly olderPost: Maybe<PostDetailFragment>, readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'siteUrl'> }> };
-
 type ChangelogTemplateQueryVariables = Exact<{
   id: Scalars['String'];
   newerId: Maybe<Scalars['String']>;
@@ -4009,6 +3999,20 @@ type ChangelogTemplateQuery = { readonly changelog: Maybe<(
     Pick<MarkdownRemark, 'html'>
     & { readonly fields: Pick<Fields, 'slug'> }
   )>, readonly newerChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }>, readonly olderChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }> };
+
+type PostTemplateQueryVariables = Exact<{
+  id: Scalars['String'];
+  newerId: Maybe<Scalars['String']>;
+  olderId: Maybe<Scalars['String']>;
+}>;
+
+
+type PostTemplateQuery = { readonly post: Maybe<PostDetailFragment>, readonly newerPost: Maybe<PostDetailFragment>, readonly olderPost: Maybe<PostDetailFragment>, readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'siteUrl'> }> };
+
+type ChangelogQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type ChangelogQuery = { readonly allChangelog: { readonly nodes: ReadonlyArray<{ readonly fields: Pick<Fields, 'slug'> }> } };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 

--- a/types/generated-types.d.ts
+++ b/types/generated-types.d.ts
@@ -786,7 +786,6 @@ type ImageSharpResize = {
 
 type Frontmatter = {
   readonly date: Scalars['Date'];
-  readonly description: Scalars['String'];
   readonly lang: Scalars['String'];
   readonly tags: ReadonlyArray<Scalars['String']>;
   readonly title: Scalars['String'];
@@ -1159,7 +1158,6 @@ type MarkdownRemarkFilterInput = {
 
 type FrontmatterFilterInput = {
   readonly date: Maybe<DateQueryOperatorInput>;
-  readonly description: Maybe<StringQueryOperatorInput>;
   readonly lang: Maybe<StringQueryOperatorInput>;
   readonly tags: Maybe<StringQueryOperatorInput>;
   readonly title: Maybe<StringQueryOperatorInput>;
@@ -1422,7 +1420,6 @@ type FileFieldsEnum =
   | 'childrenMarkdownRemark'
   | 'childrenMarkdownRemark.id'
   | 'childrenMarkdownRemark.frontmatter.date'
-  | 'childrenMarkdownRemark.frontmatter.description'
   | 'childrenMarkdownRemark.frontmatter.lang'
   | 'childrenMarkdownRemark.frontmatter.tags'
   | 'childrenMarkdownRemark.frontmatter.title'
@@ -1520,7 +1517,6 @@ type FileFieldsEnum =
   | 'childrenMarkdownRemark.internal.type'
   | 'childMarkdownRemark.id'
   | 'childMarkdownRemark.frontmatter.date'
-  | 'childMarkdownRemark.frontmatter.description'
   | 'childMarkdownRemark.frontmatter.lang'
   | 'childMarkdownRemark.frontmatter.tags'
   | 'childMarkdownRemark.frontmatter.title'
@@ -3521,7 +3517,6 @@ type MarkdownRemarkEdge = {
 type MarkdownRemarkFieldsEnum =
   | 'id'
   | 'frontmatter.date'
-  | 'frontmatter.description'
   | 'frontmatter.lang'
   | 'frontmatter.tags'
   | 'frontmatter.title'
@@ -3963,30 +3958,15 @@ type ImageSharpSortInput = {
   readonly order: Maybe<ReadonlyArray<Maybe<SortOrderEnum>>>;
 };
 
+type SiteMetaDataQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+type SiteMetaDataQuery = { readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'image'> }> };
+
 type ChangelogQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 type ChangelogQuery = { readonly allChangelog: { readonly nodes: ReadonlyArray<{ readonly fields: Pick<Fields, 'slug'> }> } };
-
-type PostDetailFragment = (
-  Pick<MarkdownRemark, 'id' | 'html' | 'excerpt'>
-  & { readonly fields: Pick<Fields, 'slug'>, readonly frontmatter: (
-    Pick<Frontmatter, 'title' | 'description' | 'date' | 'tags' | 'lang'>
-    & { readonly featuredImage: Maybe<(
-      Pick<File, 'publicURL'>
-      & { readonly childImageSharp: Maybe<Pick<ImageSharp, 'gatsbyImageData'>> }
-    )> }
-  ) }
-);
-
-type BlogTemplateQueryVariables = Exact<{
-  skip: Maybe<Scalars['Int']>;
-  limit: Maybe<Scalars['Int']>;
-  filterValue: Maybe<Scalars['String']>;
-}>;
-
-
-type BlogTemplateQuery = { readonly posts: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly tags: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly langs: { readonly nodes: ReadonlyArray<PostDetailFragment> } };
 
 type ChangelogTemplateQueryVariables = Exact<{
   id: Scalars['String'];
@@ -4000,10 +3980,16 @@ type ChangelogTemplateQuery = { readonly changelog: Maybe<(
     & { readonly fields: Pick<Fields, 'slug'> }
   )>, readonly newerChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }>, readonly olderChangelog: Maybe<{ readonly fields: Pick<Fields, 'slug'> }> };
 
-type SiteMetaDataQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-type SiteMetaDataQuery = { readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'title' | 'description' | 'siteUrl' | 'image'> }> };
+type PostDetailFragment = (
+  Pick<MarkdownRemark, 'id' | 'html' | 'excerpt'>
+  & { readonly fields: Pick<Fields, 'slug'>, readonly frontmatter: (
+    Pick<Frontmatter, 'title' | 'date' | 'tags' | 'lang'>
+    & { readonly featuredImage: Maybe<(
+      Pick<File, 'publicURL'>
+      & { readonly childImageSharp: Maybe<Pick<ImageSharp, 'gatsbyImageData'>> }
+    )> }
+  ) }
+);
 
 type PostTemplateQueryVariables = Exact<{
   id: Scalars['String'];
@@ -4013,6 +3999,15 @@ type PostTemplateQueryVariables = Exact<{
 
 
 type PostTemplateQuery = { readonly post: Maybe<PostDetailFragment>, readonly newerPost: Maybe<PostDetailFragment>, readonly olderPost: Maybe<PostDetailFragment>, readonly site: Maybe<{ readonly siteMetadata: Pick<SiteSiteMetadata, 'siteUrl'> }> };
+
+type BlogTemplateQueryVariables = Exact<{
+  skip: Maybe<Scalars['Int']>;
+  limit: Maybe<Scalars['Int']>;
+  filterValue: Maybe<Scalars['String']>;
+}>;
+
+
+type BlogTemplateQuery = { readonly posts: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly tags: { readonly nodes: ReadonlyArray<PostDetailFragment> }, readonly langs: { readonly nodes: ReadonlyArray<PostDetailFragment> } };
 
 type GatsbyImageSharpFixedFragment = Pick<ImageSharpFixed, 'base64' | 'width' | 'height' | 'src' | 'srcSet'>;
 

--- a/types/schema.json
+++ b/types/schema.json
@@ -3365,6 +3365,18 @@
             "deprecationReason": null
           },
           {
+            "name": "excerpt_separator",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "maxWidth",
             "description": null,
             "args": [],
@@ -21185,6 +21197,18 @@
             "deprecationReason": null
           },
           {
+            "name": "excerpt_separator",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringQueryOperatorInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "maxWidth",
             "description": null,
             "type": {
@@ -23318,6 +23342,12 @@
             "deprecationReason": null
           },
           {
+            "name": "pluginCreator___pluginOptions___excerpt_separator",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pluginCreator___pluginOptions___maxWidth",
             "description": null,
             "isDeprecated": false,
@@ -24919,6 +24949,12 @@
           },
           {
             "name": "pluginOptions___name",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pluginOptions___excerpt_separator",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null

--- a/types/schema.json
+++ b/types/schema.json
@@ -7424,22 +7424,6 @@
             "deprecationReason": null
           },
           {
-            "name": "description",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "lang",
             "description": null,
             "args": [],
@@ -10839,18 +10823,6 @@
             "deprecationReason": null
           },
           {
-            "name": "description",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringQueryOperatorInput",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "lang",
             "description": null,
             "type": {
@@ -13180,12 +13152,6 @@
             "deprecationReason": null
           },
           {
-            "name": "childrenMarkdownRemark___frontmatter___description",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "childrenMarkdownRemark___frontmatter___lang",
             "description": null,
             "isDeprecated": false,
@@ -13763,12 +13729,6 @@
           },
           {
             "name": "childMarkdownRemark___frontmatter___date",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "childMarkdownRemark___frontmatter___description",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -27801,12 +27761,6 @@
           },
           {
             "name": "frontmatter___date",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "frontmatter___description",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
Closes #153 

- remove description field from markdown frontmatter
- use excerpt as description

use `<!-- excerpt -->` as separator.