### PR TITLE
Update setup node to v3 and use its own caching

### DIFF
--- a/.github/workflows/deploy-content.yml
+++ b/.github/workflows/deploy-content.yml
@@ -23,27 +23,10 @@ jobs:
         run: git checkout master content/
 
       - name: Install NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Get local node modules directory path
-        id: yarn-node-modules-path
-        run: echo "::set-output name=dir::$(pwd)/node_modules"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            ${{ steps.yarn-node-modules-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: "16.x"
+          cache: "yarn"
 
       - name: Install netlify cli
         run: yarn global add netlify-cli

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -17,27 +17,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Get local node modules directory path
-        id: yarn-node-modules-path
-        run: echo "::set-output name=dir::$(pwd)/node_modules"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            ${{ steps.yarn-node-modules-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: "16.x"
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,27 +16,10 @@ jobs:
           submodules: recursive
 
       - name: Install NodeJS
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Get local node modules directory path
-        id: yarn-node-modules-path
-        run: echo "::set-output name=dir::$(pwd)/node_modules"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            ${{ steps.yarn-node-modules-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: "16.x"
+          cache: "yarn"
 
       - name: Install netlify cli
         run: yarn global add netlify-cli


### PR DESCRIPTION
- [x] depends on #220 
- Update setup node to v3
- Update node version to v16.x
- Remove action cache
- Use setup node default caching options