### PR TITLE
Use action gh release and auto generate release content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,7 @@ jobs:
       - name: Checkout master
         uses: actions/checkout@v3
 
-      - name: Get Tag
-        id: get-tag
-        run: echo "::set-output name=tag::$(echo ${{ github.ref }} | cut -d '/' -f3)"
-
       - name: Release tag
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: "Please visit <https://gagahpangeran.com>! You can also check [changelog of this release](https://gagahpangeran.com/changelog/${{ steps.get-tag.outputs.tag }})."
+          generate_release_notes: true


### PR DESCRIPTION
- [x] depends on #221 
- Change action `create-release` (deprecated) to `action-gh-release`.
- Use auto generated release content page.