### PR TITLE
Add markdown blockquote styling

### DIFF
--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -12,6 +12,19 @@
     }
   }
 
+  figcaption {
+    font-weight: bold;
+    color: var(--gray);
+    font-style: italic;
+    font-size: 1rem;
+    margin-top: 8px;
+    padding: 0 16px;
+  }
+
+  figure {
+    text-align: center;
+  }
+
   h2 {
     color: var(--gray);
   }
@@ -22,26 +35,8 @@
     border-radius: var(--image-border-radius);
   }
 
-  p {
-    margin: 16px 0;
-    line-height: 150%;
-  }
-
-  figure {
-    text-align: center;
-  }
-
-  figcaption {
-    font-weight: bold;
-    color: var(--gray);
-    font-style: italic;
-    font-size: 1rem;
-    margin-top: 8px;
-    padding: 0 16px;
-  }
-
-  ul,
-  ol {
+  ol,
+  ul {
     margin-left: 24px;
 
     li {
@@ -52,6 +47,11 @@
         color: var(--gray);
       }
     }
+  }
+
+  p {
+    margin: 16px 0;
+    line-height: 150%;
   }
 
   &__header-link {

--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -12,6 +12,12 @@
     }
   }
 
+  blockquote {
+    padding-left: 12px;
+    border-left: 2px solid var(--gray);
+    color: var(--gray);
+  }
+
   figcaption {
     font-weight: bold;
     color: var(--gray);


### PR DESCRIPTION
Surprise this doesn't have styling yet.

Markdown syntax affected:

```
> This is blockquote
```

**Before**

![image](https://user-images.githubusercontent.com/4964985/206443764-b6c888a7-1d7d-4f5e-9b89-c566a4bde108.png)

**After**

![image](https://user-images.githubusercontent.com/4964985/206443552-5e9717bc-d0b9-4af9-b240-96611a55dd1a.png)

