### PR TITLE
Fix workflow error when installing netlify-cli

### DIFF
--- a/.github/workflows/deploy-content.yml
+++ b/.github/workflows/deploy-content.yml
@@ -47,7 +47,7 @@ jobs:
           cache: "yarn"
 
       - name: Install netlify cli
-        run: yarn global add netlify-cli
+        run: yarn global --ignore-optional add netlify-cli
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           cache: "yarn"
 
       - name: Install netlify cli
-        run: yarn global add netlify-cli
+        run: yarn global --ignore-optional add netlify-cli
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
As you can see at https://github.com/gagahpangeran/gagahpangeran.com/actions/runs/7063436803/job/19229488074.

The workflow is failed because of error
```
warning Error running install script for optional dependency: "/home/runner/.config/yarn/global/node_modules/unix-dgram: Couldn't find the binary node-gyp rebuild"
info This module is OPTIONAL, you can safely ignore this error
```

Because this module is optional, we can just safely ignore it.