### PR TITLE
CSS hotfix for overflow content in post

### DIFF
--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -3,6 +3,7 @@ header {
 
   h1 {
     font-weight: bolder;
+    overflow-wrap: break-word;
   }
 
   h2 {

--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -115,4 +115,8 @@
     text-align: center;
     margin: 16px 0;
   }
+
+  .math-display {
+    overflow-y: scroll;
+  }
 }


### PR DESCRIPTION
Oops, didn't check this on mobile when using latex equation.

Also fix wrapping for long title post.