### PR TITLE
Cleanup `Layout` component and set smooth scrolling default behavior

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,18 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text.
+
+import { Link } from "gatsby";
+import React from "react";
+
+export default function Footer() {
+  return (
+    <footer>
+      <h6>
+        &copy; 2019-{new Date().getFullYear()} GPR •{" "}
+        <Link to="/changelog/">Changelog</Link> •{" "}
+        <Link to="#top">Go To Top</Link>
+      </h6>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text.
+
+import React from "react";
+
+export interface HeaderProps {
+  mainTitle?: string;
+  subTitle?: string;
+}
+
+export default function Header({ mainTitle, subTitle }: HeaderProps) {
+  if (mainTitle === undefined) {
+    return null;
+  }
+
+  return (
+    <header id="top">
+      <h1>{mainTitle}</h1>
+      {subTitle && <h2>{subTitle}</h2>}
+    </header>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,15 +9,19 @@ export interface HeaderProps {
   subTitle?: string;
 }
 
-export default function Header({ mainTitle, subTitle }: HeaderProps) {
-  if (mainTitle === undefined) {
-    return null;
-  }
+export default function Header(props: HeaderProps) {
+  const renderHeader = ({ mainTitle, subTitle }: HeaderProps) => {
+    if (mainTitle === undefined) {
+      return null;
+    }
 
-  return (
-    <header id="top">
-      <h1>{mainTitle}</h1>
-      {subTitle && <h2>{subTitle}</h2>}
-    </header>
-  );
+    return (
+      <>
+        <h1>{mainTitle}</h1>
+        {subTitle && <h2>{subTitle}</h2>}
+      </>
+    );
+  };
+
+  return <header id="top">{renderHeader(props)}</header>;
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { config as faConfig } from "@fortawesome/fontawesome-svg-core";
 import { Link } from "gatsby";
 import React from "react";
 import Navbar from "./Navbar";
+import Header, { HeaderProps } from "./Header";
 
 interface Props extends HeaderProps {
   children: React.ReactNode;
@@ -25,24 +26,6 @@ const Layout = ({ children, ...headerProps }: Props) => {
 };
 
 export default Layout;
-
-interface HeaderProps {
-  mainTitle?: string;
-  subTitle?: string;
-}
-
-const Header = ({ mainTitle, subTitle }: HeaderProps) => {
-  if (mainTitle === undefined) {
-    return null;
-  }
-
-  return (
-    <header id="top">
-      <h1>{mainTitle}</h1>
-      {subTitle && <h2>{subTitle}</h2>}
-    </header>
-  );
-};
 
 const Footer = () => {
   return (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,20 +45,12 @@ const Header = ({ mainTitle, subTitle }: HeaderProps) => {
 };
 
 const Footer = () => {
-  const goToTop = () => {
-    window.scroll({
-      top: 0,
-      left: 0,
-      behavior: "smooth"
-    });
-  };
-
   return (
     <footer>
       <h6>
         &copy; 2019-{new Date().getFullYear()} GPR •{" "}
         <Link to="/changelog/">Changelog</Link> •{" "}
-        <span onClick={goToTop}>Go To Top</span>
+        <Link to="#top">Go To Top</Link>
       </h6>
     </footer>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -37,7 +37,7 @@ const Header = ({ mainTitle, subTitle }: HeaderProps) => {
   }
 
   return (
-    <header>
+    <header id="top">
       <h1>{mainTitle}</h1>
       {subTitle && <h2>{subTitle}</h2>}
     </header>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,10 +3,10 @@
 // Read the LICENSE file in the repository root for full license text.
 
 import { config as faConfig } from "@fortawesome/fontawesome-svg-core";
-import { Link } from "gatsby";
 import React from "react";
 import Navbar from "./Navbar";
 import Header, { HeaderProps } from "./Header";
+import Footer from "./Footer";
 
 interface Props extends HeaderProps {
   children: React.ReactNode;
@@ -26,15 +26,3 @@ const Layout = ({ children, ...headerProps }: Props) => {
 };
 
 export default Layout;
-
-const Footer = () => {
-  return (
-    <footer>
-      <h6>
-        &copy; 2019-{new Date().getFullYear()} GPR •{" "}
-        <Link to="/changelog/">Changelog</Link> •{" "}
-        <Link to="#top">Go To Top</Link>
-      </h6>
-    </footer>
-  );
-};

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -31,6 +31,7 @@
 html {
   scroll-padding-top: var(--navbar-height);
   overflow: auto;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -1,6 +1,10 @@
 header {
   margin-bottom: 12px;
 
+  &:empty {
+    margin: 0;
+  }
+
   h1 {
     font-weight: bolder;
     overflow-wrap: break-word;


### PR DESCRIPTION
- Extract `Header` to its own component.
- Extract `Footer` to its own component.
- Set `scroll-behavior: smooth;` as default in CSS.
- Add `top` id in header as `go to top` target.
- Change `go to top` footer to use anchor link.