### PR TITLE
Strip markdown in post description

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text
+
+export function stripInlineMarkdown(str: string) {
+  return str
+    .replace(/\*\*(.*?)\*\*/g, "$1") // **text**
+    .replace(/_(.*?)_/g, "$1") // _text_
+    .replace(/~~(.*?)~~/g, "$1") // ~~text~~
+    .replace(/`{1,2}(.*?)`{1,2}/g, "$1") // `text` or ``text``
+    .replace(/\[(.*?)\]\(.*?\)/g, "$1") // [text](url)
+    .replace(/\[(.*?)\]\[.*?\]/g, "$1"); // [text][ref]
+}

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -6,6 +6,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { type ImageData, getContentDir, getImageData } from "./file";
+import { stripInlineMarkdown } from "./markdown";
 
 type Language = "en" | "id";
 
@@ -117,7 +118,7 @@ export function getPostBySlug(slug: string): PostData | null {
     month: "long",
     day: "2-digit"
   });
-  const description = excerpt.replaceAll("\n", " ");
+  const description = stripInlineMarkdown(excerpt.replaceAll("\n", " "));
 
   const imgPath = path.join(slug, frontmatter.featuredImage);
   const image = getImageData(imgPath);

--- a/test/fixtures/blog/my-post/index.md
+++ b/test/fixtures/blog/my-post/index.md
@@ -1,0 +1,31 @@
+---
+title: "Test Blog Post"
+date: "2025-01-29T20:00:00+07:00"
+featuredImage: "./img/thumbnail.png"
+tags: ["Story", "Cloud"]
+lang: "en"
+---
+
+Lorem ipsum **odor** amet, consectetuer adipiscing elit. Velit imperdiet
+_praesent_ congue tortor habitant senectus hendrerit penatibus. ~~Primis~~
+mollis `consequat` himenaeos non suscipit [metus][https://example.com]. Pharetra
+at adipiscing [fringilla][link] mattis pretium.
+
+<!-- excerpt -->
+
+Gravida dolor turpis habitasse sapien nulla egestas. Ex duis vivamus nibh
+fringilla curae. Euismod iaculis taciti et lorem maximus ut conubia. Suscipit
+commodo facilisis aliquam a semper cras. Mi etiam habitasse sed eget vivamus
+erat. Posuere porta tristique ut hac ante non. Eget a dis curae varius cras
+sapien tortor.
+
+Ullamcorper ultrices imperdiet vel mattis fames aliquam penatibus. Fusce
+vulputate feugiat himenaeos condimentum lacinia dictum vitae risus. Ad integer
+justo lacinia proin mauris proin. Enim enim platea, eu nisl tellus nunc ad urna.
+Id lobortis lacinia nisi elit luctus sollicitudin facilisis. Consectetur mus
+luctus felis nisi feugiat posuere conubia. Ullamcorper ac augue fringilla
+sagittis, auctor ut. Justo primis conubia suspendisse; aenean ad hac dapibus
+luctus. Pellentesque tortor suspendisse pharetra dolor convallis quisque
+laoreet. Habitasse varius leo sapien; quisque senectus platea.
+
+[link]: https://example.com

--- a/test/utils/markdown.test.ts
+++ b/test/utils/markdown.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text
+
+import { stripInlineMarkdown } from "@/utils/markdown";
+
+describe("Test stripMarkdown function", () => {
+  test("Bold", () => {
+    expect(stripInlineMarkdown("Hello **world**")).toBe("Hello world");
+  });
+
+  test("Italic", () => {
+    expect(stripInlineMarkdown("Hello _world_")).toBe("Hello world");
+  });
+
+  test("Strikethrough", () => {
+    expect(stripInlineMarkdown("Hello ~~world~~")).toBe("Hello world");
+  });
+
+  test("Code 1", () => {
+    expect(stripInlineMarkdown("Hello `world`")).toBe("Hello world");
+  });
+
+  test("Code 2", () => {
+    expect(stripInlineMarkdown("Hello ``world``")).toBe("Hello world");
+  });
+
+  test("Code 1", () => {
+    expect(stripInlineMarkdown("Hello [world](https://example.com)")).toBe(
+      "Hello world"
+    );
+  });
+
+  test("Code 2", () => {
+    expect(stripInlineMarkdown("Hello [world][link]")).toBe("Hello world");
+  });
+
+  test("Mixed bold and italic", () => {
+    expect(stripInlineMarkdown("Hello _**world**_")).toBe("Hello world");
+  });
+});

--- a/test/utils/post.test.ts
+++ b/test/utils/post.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text.
+
+import { getPostBySlug, type PostData } from "@/utils/post";
+
+beforeAll(() => {
+  process.env.CONTENT_DIR = "test/fixtures";
+});
+
+afterAll(() => {
+  process.env.CONTENT_DIR = undefined;
+});
+
+describe("test getPostBySlug function", () => {
+  test("Simple blog post", () => {
+    const expected: PostData = {
+      title: "Test Blog Post",
+      date: "January 29, 2025",
+      featuredImage: "./img/thumbnail.png",
+      tags: ["Story", "Cloud"],
+      lang: "en",
+      slug: "/blog/my-post/",
+      datetime: "2025-01-29T20:00:00+07:00",
+      image: {
+        width: 512,
+        height: 512,
+        src: "/blog/my-post/img/thumbnail.png"
+      },
+      excerpt: `Lorem ipsum **odor** amet, consectetuer adipiscing elit. Velit imperdiet
+_praesent_ congue tortor habitant senectus hendrerit penatibus. ~~Primis~~
+mollis \`consequat\` himenaeos non suscipit [metus][https://example.com]. Pharetra
+at adipiscing [fringilla][link] mattis pretium.`,
+      description: `Lorem ipsum odor amet, consectetuer adipiscing elit. Velit imperdiet praesent congue tortor habitant senectus hendrerit penatibus. Primis mollis consequat himenaeos non suscipit metus. Pharetra at adipiscing fringilla mattis pretium.`,
+      content: `Lorem ipsum **odor** amet, consectetuer adipiscing elit. Velit imperdiet
+_praesent_ congue tortor habitant senectus hendrerit penatibus. ~~Primis~~
+mollis \`consequat\` himenaeos non suscipit [metus][https://example.com]. Pharetra
+at adipiscing [fringilla][link] mattis pretium.
+
+<!-- excerpt -->
+
+Gravida dolor turpis habitasse sapien nulla egestas. Ex duis vivamus nibh
+fringilla curae. Euismod iaculis taciti et lorem maximus ut conubia. Suscipit
+commodo facilisis aliquam a semper cras. Mi etiam habitasse sed eget vivamus
+erat. Posuere porta tristique ut hac ante non. Eget a dis curae varius cras
+sapien tortor.
+
+Ullamcorper ultrices imperdiet vel mattis fames aliquam penatibus. Fusce
+vulputate feugiat himenaeos condimentum lacinia dictum vitae risus. Ad integer
+justo lacinia proin mauris proin. Enim enim platea, eu nisl tellus nunc ad urna.
+Id lobortis lacinia nisi elit luctus sollicitudin facilisis. Consectetur mus
+luctus felis nisi feugiat posuere conubia. Ullamcorper ac augue fringilla
+sagittis, auctor ut. Justo primis conubia suspendisse; aenean ad hac dapibus
+luctus. Pellentesque tortor suspendisse pharetra dolor convallis quisque
+laoreet. Habitasse varius leo sapien; quisque senectus platea.
+
+[link]: https://example.com`
+    };
+
+    const result = getPostBySlug("my-post");
+    expect(result).toMatchObject(expected);
+  });
+});


### PR DESCRIPTION
- Add `stripInlineMarkdown` utils.
- Add test for `getPostBySlug` utils.
- Add fixture for markdown post.

Still need more tests for post utils.