### PR TITLE
Fix katex container causing horizontal overflow

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -17,3 +17,4 @@
 @use "share-button.scss";
 @use "page-nav.scss";
 @use "changelog.scss";
+@use "katex.scss";

--- a/src/styles/katex.scss
+++ b/src/styles/katex.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Gagah Pangeran Rosfatiputra (GPR) <gpr@gagahpangeran.com>.
+// Licensed under The MIT License.
+// Read the LICENSE file in the repository root for full license text.
+
+.katex-display {
+  max-width: 100%;
+  overflow-y: auto;
+}


### PR DESCRIPTION
Add horizontal scroll to prevent overflow.

Before:

![image](https://github.com/user-attachments/assets/23f65a48-ea71-405d-81d7-3881e2d4d762)

After:

![image](https://github.com/user-attachments/assets/89124c2b-87d6-4d9f-a2c0-ceb2286ded9d)

